### PR TITLE
[ENH]  :sparkles: Browsing applications should not lose userStorage references

### DIFF
--- a/src/components/shared/sider/sider-body.tsx
+++ b/src/components/shared/sider/sider-body.tsx
@@ -109,8 +109,6 @@ const SiderBody = () => {
 					} else {
 						push('/realm/' + match?.params?.realm);
 					}
-				} else {
-					setStorageSelected(undefined);
 				}
 			} else {
 				push('/');


### PR DESCRIPTION
(#308)

Signed-off-by: Emmanuel Barrios <emmanuel.barrios@insee.fr>